### PR TITLE
add rule to detect missing key prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ module.exports = {
     'no-unused-labels': 'warn',
     'radix': 'warn',
     'spaced-comment': 'warn',
+    'react/jsx-key': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',
     'react/jsx-tag-spacing': 'error',


### PR DESCRIPTION
Adds https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md which gives a warning when a list or an element in an iterator does not have a unique key prop, e.g.:

```jsx
[<Hello />, <Hello />, <Hello />];
```

@terrestris/devs Please review.