### PR TITLE
disable default-case rule for switch statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = {
     'camelcase': 'warn',
     'comma-dangle': 'off',
     'curly': 'warn',
-    'default-case': 'warn',
+    'default-case': 'off',
     'dot-notation': 'warn',
     'eol-last': 'warn',
     'eqeqeq': [


### PR DESCRIPTION
Often switch statements work on enums or string unions. There it makes no sense to have a default case.